### PR TITLE
Removed 'tabs' + wildcard permissions

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 2,
     "name": "RuneScape Music",
     "description": "This extension will play a random song from the RuneScape Soundtrack.",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "background": {
         "scripts": [
             "/scripts/background.js"
@@ -10,9 +10,6 @@
         "persistent": true
     },
     "permissions": [
-        "https://*/*",
-        "http://*/*",
-        "tabs",
         "unlimitedStorage"
     ],
     "icons": {


### PR DESCRIPTION
Currently you have the `tabs` permission, alongside wildcard access to **any** webpage the user has access to, I tested the extension without it and it works perfectly fine as the music is playing in the background script (which is a tab of it's own), so there's no need for these permissions.

Reason for the pull request: I didn't feel comfortable having an extension I don't 110% trust read all of my data on websites (including https://www.runescape.com/), which might also be a deterrent for other people that might want to install your extension as the extension could technically swoop in and steal anyone's passwords when they log into the main website

---

Edit: PS, I love the extension, just don't love the permissions :)